### PR TITLE
fix: remove userId from leaderboard api

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,9 +9,6 @@ import Header from './components/common/header/Header';
 import Dashboard from './pages/dashboard/Dashboard';
 import LeaderboardPage from './pages/leaderboard/Leaderboard';
 
-// It will be removed and userId will be passed as Props to Leaderboard component
-const userId = '5c7c4f26e2168b648bcdd3e2';
-
 const App = () => (
   <BrowserRouter>
     <Header>
@@ -21,11 +18,7 @@ const App = () => (
         <Route exact path="/signup" component={SignUp} />
         <Route exact path="/forgotPassword" component={ForgotPassword} />
         <Route exact path="/dashboard" component={Dashboard} />
-        <Route
-          exact
-          path="/leaderboard"
-          render={routeProps => <LeaderboardPage {...{ userId }} {...routeProps} />}
-        />
+        <Route exact path="/leaderboard" component={LeaderboardPage} />
         <Route exact path="*" component={Page404} />
       </Switch>
     </Header>

--- a/client/src/pages/leaderboard/Leaderboard.js
+++ b/client/src/pages/leaderboard/Leaderboard.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import {
   Grid, GridColumn, GridRow, Header,
 } from 'semantic-ui-react';
@@ -11,7 +10,7 @@ import {
   getPersonalRank,
 } from '../../utils/leaderboard_api';
 
-const Leaderboard = ({ userId }) => {
+const Leaderboard = () => {
   const [users, setUsers] = useState([]);
   const [pageCount, setPageCount] = useState(1);
   const [personalScore, setPersonalScore] = useState('loading...');
@@ -27,9 +26,9 @@ const Leaderboard = ({ userId }) => {
   };
 
   const getPageInfo = async () => {
-    const score = await getPersonalScore({ userId });
+    const score = await getPersonalScore();
     setPersonalScore(score);
-    const rank = await getPersonalRank({ userId });
+    const rank = await getPersonalRank();
     setPersonalRank(rank);
   };
 
@@ -89,10 +88,6 @@ const Leaderboard = ({ userId }) => {
       </Grid>
     </div>
   );
-};
-
-Leaderboard.propTypes = {
-  userId: PropTypes.string.isRequired,
 };
 
 export default Leaderboard;

--- a/client/src/pages/leaderboard/Leaderboard.test.js
+++ b/client/src/pages/leaderboard/Leaderboard.test.js
@@ -7,7 +7,7 @@ import Leaderboard from './Leaderboard';
 import ScoreTable from './ScoreTable';
 
 describe('<Leaderboard /> Page', () => {
-  const wrapper = shallow(<Leaderboard userId="abc" />);
+  const wrapper = shallow(<Leaderboard />);
 
   it('should render a div', () => {
     expect(wrapper.find('div').length).toBe(1);

--- a/client/src/utils/leaderboard_api.js
+++ b/client/src/utils/leaderboard_api.js
@@ -27,24 +27,20 @@ const getUsersAndPageCount = async ({ currentPage }) => {
   return [users, pageCount];
 };
 
-const getPersonalScore = async ({ userId }) => {
-  const fetchedData = await get(`${leaderboardRoute}/user`, {
-    userId,
-  });
+const getPersonalScore = async () => {
+  const fetchedData = await get(`${leaderboardRoute}/user`);
   const personalScores = fetchedData.data;
-  if (personalScores) {
+  if (personalScores[0]) {
     const personalHighScore = personalScores[0].value;
     return personalHighScore;
   }
   return 0;
 };
 
-const getPersonalRank = async ({ userId }) => {
+const getPersonalRank = async () => {
   // Needs refactoring based on server side fixes
   try {
-    const fetchedPersonalRank = await get(`${leaderboardRoute}/rank`, {
-      userId,
-    });
+    const fetchedPersonalRank = await get(`${leaderboardRoute}/rank`);
     return fetchedPersonalRank.data;
   } catch (error) {
     return 0;

--- a/client/src/utils/leaderboard_api.test.js
+++ b/client/src/utils/leaderboard_api.test.js
@@ -77,14 +77,14 @@ describe('Leaderboard data manipulation Helper functions', () => {
 
   describe('getPersonalScores', () => {
     it('should return High Score for specified user', async () => {
-      const score = await getPersonalScore({ userId: '' });
+      const score = await getPersonalScore();
       expect(score).toBe(sampleScores[0].value);
     });
   });
 
   describe('getPersonalRank', () => {
     it('should return Rank for specified user', async () => {
-      const rank = await getPersonalRank({ userId: '' });
+      const rank = await getPersonalRank();
       expect(rank).toBe(2);
     });
   });

--- a/server/src/controllers/score.controller.js
+++ b/server/src/controllers/score.controller.js
@@ -33,7 +33,7 @@ const getScores = async (req, res) => {
 };
 
 const getUserRank = async (req, res) => {
-  const { userId } = req.query;
+  const userId = req.user.id;
   sendResultOrError({
     query: queryRank(userId),
     successStatus: HTTP_SUCCESS_OK,
@@ -43,7 +43,7 @@ const getUserRank = async (req, res) => {
 };
 
 const getUserScores = async (req, res) => {
-  const { userId } = req.query;
+  const userId = req.user.id;
   sendResultOrError({
     query: queryUserScore(userId),
     successStatus: HTTP_SUCCESS_OK,
@@ -53,7 +53,8 @@ const getUserScores = async (req, res) => {
 };
 
 const createScore = async (req, res) => {
-  const { userId, value } = req.body;
+  const userId = req.user.id;
+  const { value } = req.body;
   sendResultOrError({
     query: insertScore(userId, value),
     successStatus: HTTP_CREATED,

--- a/server/src/controllers/score.controller.test.js
+++ b/server/src/controllers/score.controller.test.js
@@ -57,13 +57,14 @@ insertScore.mockImplementation(async (userId, value) => {
 describe('Score API controllers', () => {
   const req = {
     body: {
-      userId: '5abc',
       value: 30,
+    },
+    user: {
+      id: '5abc',
     },
     query: {
       offset: '2',
       limit: '10',
-      userId: '5abc',
     },
   };
   const res = {
@@ -130,7 +131,7 @@ describe('Score API controllers', () => {
       });
 
       it('should query DB with userID', () => {
-        expect(queryRank).toBeCalledWith(req.query.userId);
+        expect(queryRank).toBeCalledWith(req.user.id);
       });
 
       it('should set HTTP STATUS OK on success', () => {
@@ -144,12 +145,12 @@ describe('Score API controllers', () => {
 
     describe('FAILURE', () => {
       beforeEach(() => {
-        req.query.userId = null; // To create error
+        req.user.id = null; // To create error
         getUserRank(req, res);
       });
 
       afterEach(() => {
-        req.query.userId = '5abc'; // Restore after error Testing
+        req.user.id = '5abc'; // Restore after error Testing
       });
 
       it('should set HTTP SERVER ERROR on fail', () => {
@@ -169,7 +170,7 @@ describe('Score API controllers', () => {
       });
 
       it('should call db function with userID', () => {
-        expect(queryUserScore).toBeCalledWith(req.query.userId);
+        expect(queryUserScore).toBeCalledWith(req.user.id);
       });
 
       it('should set HTTP STATUS OK on success', () => {
@@ -183,7 +184,7 @@ describe('Score API controllers', () => {
 
     describe('FAILURE', () => {
       beforeEach(() => {
-        req.query.userId = null; // To create error
+        req.user.id = null; // To create error
         getUserScores(req, res);
       });
 
@@ -193,6 +194,10 @@ describe('Score API controllers', () => {
 
       it('should send error in response on fail', () => {
         expect(res.jsonData.error).toEqual(error);
+      });
+
+      afterEach(() => {
+        req.user.id = '5abc';
       });
     });
   });
@@ -204,7 +209,7 @@ describe('Score API controllers', () => {
       });
 
       it('should call db function with userId and value', () => {
-        expect(insertScore).toBeCalledWith(req.body.userId, req.body.value);
+        expect(insertScore).toBeCalledWith(req.user.id, req.body.value);
       });
 
       it('should set HTTP CREATED status on success', () => {

--- a/server/src/routes/score.route.test.js
+++ b/server/src/routes/score.route.test.js
@@ -15,7 +15,6 @@ describe('Leaderboard APIs and DB fetch', async () => {
   let baseUrl;
   let generateUrl;
   const sampleUser = {
-    userId: users[0]._id, // eslint-disable-line no-underscore-dangle
     value: 20,
   };
   // To be saved in DB before running GET API request Tests
@@ -103,10 +102,9 @@ describe('Leaderboard APIs and DB fetch', async () => {
 
     describe('GET /api/leaderboard/rank', () => {
       it('should get User Rank', async () => {
-        // This User has third highest score, so rank should be 3
-        const expectedRank = 3;
-        const { user } = DBScores[2];
-        const url = generateUrl(`/api/leaderboard/rank?userId=${user}`);
+        // This User whose token is used, has first highest score
+        const expectedRank = 1;
+        const url = generateUrl(`/api/leaderboard/rank`);
         const res = await fetch(url, {
           headers: {
             'x-auth': tokens[0],
@@ -120,8 +118,7 @@ describe('Leaderboard APIs and DB fetch', async () => {
     describe('GET /api/leaderboard/user', () => {
       let scoreCard;
       beforeAll(async () => {
-        const { user } = DBScores[0];
-        const url = generateUrl(`/api/leaderboard/user?userId=${user}`);
+        const url = generateUrl(`/api/leaderboard/user`);
         const res = await fetch(url, {
           headers: {
             'x-auth': tokens[0],


### PR DESCRIPTION
- userID is already included in the request by auth middleware for the authenticated user
- so, it's not required in requests manually

fixes #43